### PR TITLE
Remove broken link to Chrome Web Store and mark this as historical

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 **Alerts of suspicious new posts on Stack Exchange, as well as of spam reports in chat.**
 
+**Note:** This is a historic repository of code whose canonical repository is now at 
+https://github.com/Charcoal-SE/userscripts/blob/master/spamtracker/
+
 Adds a spam tracker to Stack Exchange chat rooms. Its switch is in the footer:
 
     spamtracker: off | help | faq | legal | ... 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 **Alerts of suspicious new posts on Stack Exchange, as well as of spam reports in chat.**
 
-*This Chrome extension is also available in [Chrome Web Store](https://chrome.google.com/webstore/detail/fight-spam-on-se-sites/pkpdgmdicibddkgkikdfnaggkdobhmgk)*
-
 Adds a spam tracker to Stack Exchange chat rooms. Its switch is in the footer:
 
     spamtracker: off | help | faq | legal | ... 


### PR DESCRIPTION
The link no longer works, so remove it for now.
